### PR TITLE
Strip _source from LoadTableResponse

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/tables/ForeignTableConverter.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/tables/ForeignTableConverter.java
@@ -22,7 +22,6 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.polaris.core.entity.ForeignTableEntity;
-import org.apache.polaris.core.entity.TableLikeEntity;
 import org.apache.xtable.model.storage.TableFormat;
 
 public interface ForeignTableConverter {
@@ -30,7 +29,8 @@ public interface ForeignTableConverter {
   Table convert(ForeignTableEntity entity) throws ConversionFailureException;
 
   static LoadTableResponse loadTable(ForeignTableEntity entity) {
-    ForeignTableEntity sourceStrippedEntity = new ForeignTableEntity.Builder(entity).setSource(null).build();
+    ForeignTableEntity sourceStrippedEntity =
+        new ForeignTableEntity.Builder(entity).setSource(null).build();
     if (TableFormat.DELTA.equalsIgnoreCase(entity.getSource())) {
       Table table = new DeltaTableConverter().convert(sourceStrippedEntity);
       return LoadTableResponse.builder()

--- a/polaris-core/src/main/java/org/apache/polaris/core/tables/ForeignTableConverter.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/tables/ForeignTableConverter.java
@@ -22,6 +22,7 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.polaris.core.entity.ForeignTableEntity;
+import org.apache.polaris.core.entity.TableLikeEntity;
 import org.apache.xtable.model.storage.TableFormat;
 
 public interface ForeignTableConverter {
@@ -29,8 +30,9 @@ public interface ForeignTableConverter {
   Table convert(ForeignTableEntity entity) throws ConversionFailureException;
 
   static LoadTableResponse loadTable(ForeignTableEntity entity) {
+    ForeignTableEntity sourceStrippedEntity = new ForeignTableEntity.Builder(entity).setSource(null).build();
     if (TableFormat.DELTA.equalsIgnoreCase(entity.getSource())) {
-      Table table = new DeltaTableConverter().convert(entity);
+      Table table = new DeltaTableConverter().convert(sourceStrippedEntity);
       return LoadTableResponse.builder()
           .withTableMetadata(((BaseTable) table).operations().current())
           .build();

--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/PolarisCatalogHandlerWrapper.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/PolarisCatalogHandlerWrapper.java
@@ -577,11 +577,15 @@ public class PolarisCatalogHandlerWrapper {
       throw new BadRequestException("Cannot create table on external catalogs.");
     }
 
-    LoadTableResponse response = doCatalogOperation(() -> CatalogHandlers.createTable(baseCatalog, namespace, request));
+    LoadTableResponse response =
+        doCatalogOperation(() -> CatalogHandlers.createTable(baseCatalog, namespace, request));
     TableIdentifier tableIdentifier = TableIdentifier.of(namespace, request.name());
-    PolarisBaseEntity tableEntity = ((BasePolarisCatalog)baseCatalog).getTableEntity(tableIdentifier);
+    PolarisBaseEntity tableEntity =
+        ((BasePolarisCatalog) baseCatalog).getTableEntity(tableIdentifier);
     if (tableEntity.getSubType() == PolarisEntitySubType.FOREIGN_TABLE) {
-      response =  doCatalogOperation(() -> ForeignTableConverter.loadTable(new ForeignTableEntity(tableEntity)));
+      response =
+          doCatalogOperation(
+              () -> ForeignTableConverter.loadTable(new ForeignTableEntity(tableEntity)));
     }
 
     return response;


### PR DESCRIPTION
Currently, we leave _source on the converted object which may confuse the Spark client